### PR TITLE
Allow specifying API key via environment variable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,9 @@ Usage
 
   python zone-import.py [-k apikey] [--ote] first-zone.txt second-zone.txt […]
 
-Script will ask for your API key if not provided in arguments.
+The API key can also be specified via the environment variable ``GANDI_API_KEY``.
+
+Script will ask for your API key if not provided in arguments or environment.
 
 Each zone will be name from its file name.
 

--- a/zone-import.py
+++ b/zone-import.py
@@ -16,6 +16,7 @@ multiple times will result in the same zone names being created
 from __future__ import unicode_literals, print_function
 
 import sys
+import os
 import os.path
 import argparse
 
@@ -46,7 +47,10 @@ def main():
 
     target = 'ote' if args.ote else 'production'
     if not args.key:
-        args.key = raw_input('Enter API Key (%s): ' % target)
+        if "GANDI_API_KEY" in os.environ:
+            args.key = os.environ["GANDI_API_KEY"]
+        else:
+            args.key = raw_input('Enter API Key (%s): ' % target)
 
     REMOTE = ServerProxy(RPC[target])
 


### PR DESCRIPTION
Any user on the system can view a process's arguments, but viewing the
environment of other users is not generally possible as unprivileged
users on UNIX systems.